### PR TITLE
Improved error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,8 @@
 yarn-debug.log*
 .yarn-integrity
 
-
+# Redis backup data file
+/dump.rdb
 
 /app/assets/builds/*
 !/app/assets/builds/.keep

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,1 +1,2 @@
+redis: redis-server
 web: unset PORT && bin/rails server

--- a/app/controllers/v1/forecasts_controller.rb
+++ b/app/controllers/v1/forecasts_controller.rb
@@ -6,16 +6,19 @@ module V1
       zip_code = params[:zip_code]
       days = params[:days].to_i if params[:days].present?
       days ||= 1
-      if zip_code
-        forecast_data, cached = ForecastUpdateService.update_forecast(zip_code, days)
-        if forecast_data.present?
-          render json: { forecast_data: forecast_data, cached: cached }, status: :ok
+
+      if zip_code.present?
+        result = ForecastUpdateService.update_forecast(zip_code, days)
+        if result[:success]
+          render json: { forecast_data: result[:data], cached: result[:cached] }, status: :ok
         else
-          render json: { error: 'Unable to fetch forecast data.' }, status: :not_found
+          render json: { error: { message: result[:error] || 'Unable to fetch forecast data.' } }, status: :not_found
         end
       else
-        render json: { error: 'Unable to resolve address to a zip code.' }, status: :bad_request
+        render json: { error: { message: 'Zip code is required.' } }, status: :bad_request
       end
+    rescue StandardError => e
+      render json: { error: { message: "An unexpected error occurred: #{e.message}" } }, status: :internal_server_error
     end
   end
 end

--- a/app/javascript/components/ExtendedForecast.jsx
+++ b/app/javascript/components/ExtendedForecast.jsx
@@ -9,13 +9,13 @@ const ExtendedForecast = ({ forecast }) =>  {
       <div className="flex flex-col">
         {forecast.forecastday.map((item, index) => {
             const date = parseISO(item.date);
-            const formattedDate = isToday(date) ? 'Today' : format(date, 'EEEE');
+            const formattedDate = isToday(date) ? 'Today' : format(date, 'EE');
             return (
               <div 
                 className="flex items-center justify-between border-t border-white border-opacity-75 py-2"
                 key={`${item.date}-${index}`}
               >
-                <div className="flex items-center">
+                <div className="flex justify-between items-center w-[27%]">
                   <p className="text-white">{formattedDate}</p>
                   <img
                     className="w-8 h-8"

--- a/app/javascript/components/ForecastForm.jsx
+++ b/app/javascript/components/ForecastForm.jsx
@@ -26,7 +26,8 @@ const ForecastForm = () => {
       <form onSubmit={handleSubmit} className="flex flex-col gap-4">
         <AddressAutocompleteInput onPlaceSelected={handlePlaceSelected} />
         <button
-          className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
+          className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded disabled:bg-gray-500"
+          disabled={!zipCode}
           type="submit"
         >
           Get Forecast
@@ -41,7 +42,11 @@ const ForecastForm = () => {
         )
       }
 
-      {error && <p className="text-red-500">{error}</p>}
+      {error && (
+        <div className="mt-4 p-2 rounded-lg bg-gray-700 bg-opacity-80">
+          <p className="text-red-500">{error}</p>
+        </div>
+      )}
     </div>
   );
 };

--- a/app/javascript/hooks/useForecast.js
+++ b/app/javascript/hooks/useForecast.js
@@ -8,12 +8,21 @@ const useForecast = () => {
 
   const fetchForecast = async (zipCode) => {
     setError('');
+    setForecastData(null);
+    setIsCached(false);
+
     try {
       const response = await axios.post(`/v1/forecasts/fetch_forecast`, { zip_code: zipCode, days: 10 });
       setForecastData(response.data.forecast_data);
       setIsCached(response.data.cached);
     } catch (err) {
-      setError('Failed to fetch forecast data.');
+      if (err.response && err.response.data.error) {
+        setError(err.response.data.error.message || 'Failed to fetch forecast data.');
+      } else {
+        setError('Failed to fetch forecast data.');
+      }
+      setForecastData(null);
+      setIsCached(false);
       console.error(err);
     }
   };
@@ -22,3 +31,4 @@ const useForecast = () => {
 };
 
 export default useForecast;
+

--- a/db/migrate/20240213213210_add_days_to_forecasts.rb
+++ b/db/migrate/20240213213210_add_days_to_forecasts.rb
@@ -1,0 +1,5 @@
+class AddDaysToForecasts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :forecasts, :days, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_10_145300) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_13_213210) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_10_145300) do
     t.string "zip_code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "days"
     t.index ["zip_code"], name: "index_forecasts_on_zip_code", unique: true
   end
 

--- a/spec/services/forecast_update_service_spec.rb
+++ b/spec/services/forecast_update_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ForecastUpdateService do
-  let(:zip_code) { '12345' }
+  let(:zip_code) { '10001' }
   let(:days) { 10 }
   let(:redis_key) { "forecast:#{zip_code}:days:#{days}" }
   let(:forecast_data) { { current: { temp_f: 70.0 } } }
@@ -10,7 +10,7 @@ RSpec.describe ForecastUpdateService do
   before do
     allow($redis).to receive(:get).and_return(nil)
     allow($redis).to receive(:set)
-    allow(WeatherService).to receive(:fetch_weather).and_return(forecast_data)
+    allow(WeatherService).to receive(:fetch_weather).and_return({ data: forecast_data })
     allow(Forecast).to receive(:find_by).and_return(nil)
     allow_any_instance_of(Forecast).to receive(:save!)
     allow(ForecastUpdateService).to receive(:process_weather_data).and_return(forecast_data)
@@ -19,10 +19,10 @@ RSpec.describe ForecastUpdateService do
   describe '.update_forecast' do
     context 'when data is not cached' do
       it 'fetches data from the WeatherService and updates the cache' do
-        result, cached = ForecastUpdateService.update_forecast(zip_code, days)
+        result = ForecastUpdateService.update_forecast(zip_code, days)
 
-        expect(cached).to be false
-        expect(result).to eq(forecast_data)
+        expect(result[:cached]).to be false
+        expect(result[:data]).to eq(forecast_data)
         expect($redis).to have_received(:set).with(redis_key, serialized_forecast_data, ex: ForecastUpdateService::EXPIRATION_IN_SECONDS)
       end
     end
@@ -33,30 +33,28 @@ RSpec.describe ForecastUpdateService do
       end
 
       it 'returns data from the cache without hitting the WeatherService' do
-        result, cached = ForecastUpdateService.update_forecast(zip_code, days)
+        result = ForecastUpdateService.update_forecast(zip_code, days)
 
-        expect(cached).to be true
-        expect(result).to eq(forecast_data)
+        expect(result[:cached]).to be true
+        expect(result[:data]).to eq(forecast_data)
         expect(WeatherService).not_to have_received(:fetch_weather)
       end
     end
 
     context 'when data is cached in the database but not in Redis' do
-      let(:forecast) { Forecast.new(zip_code: zip_code, forecast_data: forecast_data) }
+      let(:forecast) { Forecast.new(zip_code: zip_code, forecast_data: forecast_data, days: days) }
     
       before do
         allow(Forecast).to receive(:find_by).with(zip_code: zip_code).and_return(forecast)
         allow(forecast).to receive(:expired?).and_return(false)
-        allow($redis).to receive(:set).with("forecast:#{zip_code}:days:#{days}", forecast.forecast_data.to_json, ex: ForecastUpdateService::EXPIRATION_IN_SECONDS)
+        allow(forecast.days)
       end
     
       it 'returns data from the database and refreshes the Redis cache' do
-        result, cached = ForecastUpdateService.update_forecast(zip_code, days)
+        result = ForecastUpdateService.update_forecast(zip_code, days)
     
-        expected_result = { "current" => { "temp_f" => 70.0 } }
-        expect(result).to eq(expected_result)
-    
-        expect(cached).to be true
+        expect(result[:cached]).to be true
+        expect(result[:data]).to eq(JSON.parse(forecast_data.to_json))
         expect($redis).to have_received(:set).with(redis_key, forecast_data.to_json, ex: ForecastUpdateService::EXPIRATION_IN_SECONDS)
       end
     end
@@ -70,16 +68,17 @@ RSpec.describe ForecastUpdateService do
       before do
         allow($redis).to receive(:get).with(redis_key).and_return(serialized_forecast_data)
         allow($redis).to receive(:get).with(new_redis_key).and_return(nil)
-        allow(WeatherService).to receive(:fetch_weather).with(zip_code, new_days).and_return(new_forecast_data)
+        allow(WeatherService).to receive(:fetch_weather).with(zip_code, days).and_return({ data: forecast_data })
+        allow(WeatherService).to receive(:fetch_weather).with(zip_code, new_days).and_return({ data: new_forecast_data })
         allow(ForecastUpdateService).to receive(:process_weather_data).with(new_forecast_data).and_return(new_forecast_data)
       end
     
       it 'fetches new data from the WeatherService for the new days and updates the cache' do
-        ForecastUpdateService.update_forecast(zip_code, days) # Initial request
-        new_result, new_cached = ForecastUpdateService.update_forecast(zip_code, new_days) # Subsequent request with different days
-    
-        expect(new_cached).to be false
-        expect(new_result).to eq(new_forecast_data)
+        ForecastUpdateService.update_forecast(zip_code, days)
+        new_result = ForecastUpdateService.update_forecast(zip_code, new_days)
+      
+        expect(new_result[:cached]).to be false
+        expect(new_result[:data]).to eq(new_forecast_data)
         expect($redis).to have_received(:set).with(new_redis_key, new_serialized_forecast_data, ex: ForecastUpdateService::EXPIRATION_IN_SECONDS)
       end
     end    

--- a/spec/services/weather_service_spec.rb
+++ b/spec/services/weather_service_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe WeatherService do
   describe '.fetch_weather' do
     let(:zip_code) { '12345' }
-    let(:api_key) { 'WEATHER_API_TEST_KEY' }
+    let(:api_key) { "WEATHER_API_TEST_KEY" }
     let(:url) { "https://api.weatherapi.com/v1/forecast.json" }
     let(:days) { 1 }
 
@@ -18,28 +18,29 @@ RSpec.describe WeatherService do
           .to_return(status: status, body: body, headers: {})
       end
 
-      it 'returns the parsed JSON response' do
+      it 'returns a hash with data key containing the parsed JSON response' do
         result = described_class.fetch_weather(zip_code, days)
         expect(result).to be_a(Hash)
-        expect(result['location']['name']).to eq('Some City')
+        expect(result[:data]).to include("location" => include("name" => "Some City"))
       end
     end
 
-    context 'when the API call fails' do
+    context 'when the API call fails with a specific error' do
       let(:params) { { key: api_key, q: zip_code, days: days } }
-      let(:status) { 500 }
-      let(:body) { 'Internal Server Error' }
+      let(:status) { 400 }
+      let(:error_body) { { "error" => { "code" => 1006, "message" => "No matching location found." } }.to_json }
 
       before do
         stub_request(:get, url)
           .with(query: params)
-          .to_return(status: status, body: body, headers: {})
+          .to_return(status: status, body: error_body, headers: {})
       end
 
-      it 'logs an error and returns nil' do
-        expect(Rails.logger).to receive(:error).with(/WeatherService fetch_weather error/)
-        result = described_class.fetch_weather(zip_code)
-        expect(result).to be_nil
+      it 'returns a hash with an error key containing the specific error message' do
+        expect(Rails.logger).to receive(:error).with("No matching location found.")
+        result = described_class.fetch_weather(zip_code, days)
+        expect(result).to be_a(Hash)
+        expect(result[:error]).to include("Error fetching weather: No matching location found.")
       end
     end
 
@@ -52,13 +53,12 @@ RSpec.describe WeatherService do
           .to_raise(Faraday::ConnectionFailed.new('connection failed'))
       end
 
-      it 'logs an error and returns nil' do
-        expect(Rails.logger).to receive(:error).with(/WeatherService fetch_weather connection error/)
-        result = described_class.fetch_weather(zip_code)
-        expect(result).to be_nil
+      it 'returns a hash with an error key containing the connection error message' do
+        expect(Rails.logger).to receive(:error).with(/WeatherService connection error: connection failed/)
+        result = described_class.fetch_weather(zip_code, days)
+        expect(result).to be_a(Hash)
+        expect(result[:error]).to include("WeatherService connection error: connection failed")
       end
     end    
   end
 end
-
-


### PR DESCRIPTION
This adds more sophisticated error handling for the fetch_forecast endpoint.

Other additions:

- A `days` column added to our `forecasts` table, to track and overwrite, if necessary, our forecast record.
- There are also some minor frontend UI/UX improvements.
- This also fixes an issue with setting up the environment: If you didn't already have a redis server running while running the rails server, you may have had an issue using the app. This adds a command for starting up the redis server in addition to the rails server in `Procfile.dev`. Now, when running locally, we can run `bin/dev`, instead of having to start up both the rails server and redis server in different consoles. 